### PR TITLE
Use name for destination chain from runtime config

### DIFF
--- a/src/Utils/Helpers.tsx
+++ b/src/Utils/Helpers.tsx
@@ -339,7 +339,7 @@ export const computeTransferDetails = (
                 by: proposalEvents[0].by,
               },
               {
-                message: `Transfer executed on ${getNetworkName(toChainId)}`,
+                message: `Transfer executed on ${toChain?.name}`,
                 time: formatDateTimeline(proposal.timestamp),
               },
             ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
On timeline view we now use the name for the destination name from runtime config, instead of hardcoded name from function `getNetworkName`

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: #137 

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot


![Screenshot from 2021-10-22 20-33-53](https://user-images.githubusercontent.com/15053843/138533349-32689221-261a-4c36-a070-c0f3be662e7c.png)

